### PR TITLE
Adds port configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Once installed, open the command palette and do:
 
 🎉
 
+## Configuration
+
+ - `react-native-storybooks.port`: number (default: 9001)
+
 ## Features
 
 ![https://github.com/orta/vscode-react-native-storybooks/raw/master/preview.png](https://github.com/orta/vscode-react-native-storybooks/raw/master/preview.png)

--- a/package.json
+++ b/package.json
@@ -28,6 +28,17 @@
                     "when": "resourceLangId == javascript"
                 }
             ]
+        },
+        "configuration": {
+            "type": "object",
+            "title": "Configuration",
+            "properties": {
+                "react-native-storybooks.port": {
+                    "type": "number",
+                    "default": 9001,
+                    "description": "Port number"
+                }
+            }
         }
     },
     "scripts": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,6 +10,8 @@ export function activate(context: vscode.ExtensionContext) {
     let previewUri = vscode.Uri.parse('storybook://authority/preview');
     class TextDocumentContentProvider implements vscode.TextDocumentContentProvider {
         public provideTextDocumentContent(uri: vscode.Uri): string {
+            const port = vscode.workspace.getConfiguration('react-native-storybooks').get('port');
+
             return `
             <style>iframe {
                 position: fixed;
@@ -22,8 +24,8 @@ export function activate(context: vscode.ExtensionContext) {
             </style>
 
             <body onload="iframe.document.head.appendChild(ifstyle)" style="background-color:red;margin:0px;padding:0px;overflow:hidden">
-                <iframe src="http://localhost:9001" frameborder="0"></iframe>
-                <p>If you're seeing this, something is wrong :) </p>
+                <iframe src="http://localhost:${port}" frameborder="0"></iframe>
+                <p>If you're seeing this, something is wrong :) (can't find server on port ${port})</p>
             </body>
             `
         }


### PR DESCRIPTION
We're runnin' storybooks on port 7007 on a project, so let's make it work for that.

So now I can add to my `settings.json`:

```
"react-native-storybooks.port": 7007
```

Success! 🐴

(It defaults to port 9001, so it's not a breaking change)