### PR TITLE
Adds host configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Once installed, open the command palette and do:
 
 ## Configuration
 
+ - `react-native-storybooks.host`: string (default: "localhost")
  - `react-native-storybooks.port`: number (default: 9001)
 
 ## Features

--- a/package.json
+++ b/package.json
@@ -37,6 +37,11 @@
                     "type": "number",
                     "default": 9001,
                     "description": "Port number"
+                },
+                "react-native-storybooks.host": {
+                    "type": "string",
+                    "default": "localhost",
+                    "description": "Host address"
                 }
             }
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,7 @@ export function activate(context: vscode.ExtensionContext) {
     class TextDocumentContentProvider implements vscode.TextDocumentContentProvider {
         public provideTextDocumentContent(uri: vscode.Uri): string {
             const port = vscode.workspace.getConfiguration('react-native-storybooks').get('port');
+            const host = vscode.workspace.getConfiguration('react-native-storybooks').get('host');
 
             return `
             <style>iframe {
@@ -24,8 +25,8 @@ export function activate(context: vscode.ExtensionContext) {
             </style>
 
             <body onload="iframe.document.head.appendChild(ifstyle)" style="background-color:red;margin:0px;padding:0px;overflow:hidden">
-                <iframe src="http://localhost:${port}" frameborder="0"></iframe>
-                <p>If you're seeing this, something is wrong :) (can't find server on port ${port})</p>
+                <iframe src="http://${host}:${port}" frameborder="0"></iframe>
+                <p>If you're seeing this, something is wrong :) (can't find server at ${host}:${port})</p>
             </body>
             `
         }


### PR DESCRIPTION
A host option is helpful when running storybooks on a real device.  In reference to: https://github.com/orta/vscode-react-native-storybooks/issues/2

Now I can add to my settings.json:

"react-native-storybooks.host": "10.0.1.16"

(It defaults to "localhost", so it's not a breaking change)