### PR TITLE
Collapse & Expand commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,14 @@
             {
                 "command": "extension.restartConnectionToStorybooks",
                 "title": "Reconnect Storybook to VS Code"
+            },
+            {
+                "command": "extension.expandAllStories",
+                "title": "Expand stories in Storybook Explorer"
+            },
+            {
+                "command": "extension.collapseAllStories",
+                "title": "Collapse stories in Storybook Explorer"
             }
         ],
         "keybindings": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -156,6 +156,14 @@ export function activate(context: vscode.ExtensionContext) {
       vscode.commands.executeCommand("extension.openStory", currentSection, currentStories[currentIndex - 1])
     }
   })
+
+  vscode.commands.registerCommand("extension.expandAllStories", () => {
+    storiesProvider.expandAll();
+  })
+
+  vscode.commands.registerCommand("extension.collapseAllStories", () => {
+    storiesProvider.collapseAll()
+  })
 }
 
 // Loop through all globbed stories,

--- a/src/tree-provider.ts
+++ b/src/tree-provider.ts
@@ -3,19 +3,31 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 export interface Story {
-  kind: string
-  stories: string[]
+	kind: string
+	stories: string[]
 }
 
 export class StoryTreeProvider implements vscode.TreeDataProvider<Dependency> {
 
 	private _onDidChangeTreeData: vscode.EventEmitter<Dependency | undefined> = new vscode.EventEmitter<Dependency | undefined>();
 	readonly onDidChangeTreeData: vscode.Event<Dependency | undefined> = this._onDidChangeTreeData.event;
-  
-  stories: Story[]
+
+	stories: Story[]
+	initialCollapsibleState: number
 
 	constructor() {
 		this.stories = []
+		this.initialCollapsibleState = vscode.TreeItemCollapsibleState.Expanded;
+	}
+
+	collapseAll(): void {
+		this.initialCollapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
+		this.refresh();
+	}
+
+	expandAll(): void {
+		this.initialCollapsibleState = vscode.TreeItemCollapsibleState.Expanded;
+		this.refresh();
 	}
 
 	refresh(): void {


### PR DESCRIPTION
Thank you for the awesome extension update!! 📚 💥 

We have _a lot_ of stories, so being able to expand / collapse all of them is helpful. This PR adds separate expand & collapse commands until we're able to add buttons to the explorer (I wasn't able to find a way to do so).

![screen shot 2017-07-23 at 5 37 37 pm](https://user-images.githubusercontent.com/1047502/28503090-a9b924a2-6fcd-11e7-9563-463395fe74ff.png)

![collapseexpandstorybookext](https://user-images.githubusercontent.com/1047502/28503106-2532e4b0-6fce-11e7-91ba-f7d0f91424f7.gif)
