### PR TITLE
Picker / story search fix for hot reload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 out
 node_modules
+*.vsix

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -130,13 +130,13 @@ export function activate(context: vscode.ExtensionContext) {
       return
     }
 
-    currentKind = section.kind
-    currentStory = story
     setCurrentStory({ kind: section.kind, story })
   })
 
   function setCurrentStory(params: StorySelection) {
     const currentChannel = () => storybooksChannel
+    currentKind = params.kind
+    currentStory = params.story
     currentChannel().emit("setCurrentStory", params)
   }
 


### PR DESCRIPTION
Quick fix for my picker PR #23 to support hot reloading / refreshes (I wasn't saving the `currentStory` as you do for the explorer interactions 😕) - now it should work the same.