### PR TITLE
Change default port from 9001 to 7007

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ If your react-native server crashes, use the command "Reconnect Storybook to VS 
 ## Configuration
 
 -   `react-native-storybooks.host`: string (default: `"localhost"`)
--   `react-native-storybooks.port`: number (default: `9001`)
+-   `react-native-storybooks.port`: number (default: `7007`)
 -   `react-native-storybooks.storyRegex`: string (default: `"**/*.story.*"`)
 -   `react-native-storybooks.storybookFilterRegex`: string (default: `"."`)
 

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
       "properties": {
         "react-native-storybooks.port": {
           "type": "number",
-          "default": 9001,
+          "default": 7007,
           "description": "Port number"
         },
         "react-native-storybooks.host": {


### PR DESCRIPTION
The default port for React Native Storybook Server is 7007 [here](https://github.com/storybooks/storybook/blob/next/app/react-native-server/src/server/cli.js#L11)
Updated default port of extension to be the same.