### PR TITLE
Add support react-native-storybook@5.1.0-alpha.8

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -97,9 +97,9 @@ export function activate(context: vscode.ExtensionContext) {
           const story = data.stories[key]
           if (story.kind.match(regex)) {
             if (kinds[story.kind] == undefined) {
-              kinds[story.kind] = [story.story]
+              kinds[story.kind] = [story.name]
             } else {
-              kinds[story.kind].push(story.story)
+              kinds[story.kind].push(story.name)
             }
           }
         })

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -88,7 +88,28 @@ export function activate(context: vscode.ExtensionContext) {
     channel.on("setStories", data => {
       const filter = vscode.workspace.getConfiguration("react-native-storybooks").get("storybookFilterRegex") as string
       const regex = new RegExp(filter)
-      const stories = data.stories.filter(s => s.kind.match(regex))
+      let stories: Story[] = []
+      if (Array.isArray(data.stories)) {
+        stories = data.stories.filter(s => s.kind.match(regex))
+      } else {
+        let kinds: { [key: string]: string[] } = {}
+        Object.keys(data.stories).forEach(function(key) {
+          const story = data.stories[key]
+          if (story.kind.match(regex)) {
+            if (kinds[story.kind] == undefined) {
+              kinds[story.kind] = [story.story]
+            } else {
+              kinds[story.kind].push(story.story)
+            }
+          }
+        })
+        Object.keys(kinds).forEach(function(key) {
+          stories.push({
+            kind: key,
+            stories: kinds[key]
+          })
+        })
+      }
       storiesProvider.stories = stories
       storiesProvider.refresh()
       reconnectStatusBarItem.hide()


### PR DESCRIPTION
At version `5.1.0-alpha.8`, they used method `extract` which returns an object instead of `dumpStoryBook` which returns an array for `setStories` event.

https://github.com/storybooks/storybook/blob/v5.1.0-alpha.8/app/react-native/src/preview/index.js#L138
